### PR TITLE
Refactor app for secure sessions and cleaner image handling

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,24 +1,29 @@
 # app/main.py
-from fastapi import FastAPI, Request, Form, UploadFile, File, HTTPException
+from fastapi import FastAPI, Request, Form, UploadFile, File, HTTPException, Depends
 from fastapi.responses import HTMLResponse, JSONResponse, PlainTextResponse, RedirectResponse, FileResponse, Response
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from pathlib import Path
-from typing import Optional, List, Tuple
+from typing import Optional, List, Tuple, Iterator
 from PIL import Image, ImageOps
 from sqlmodel import SQLModel, Field, Session, create_engine, select
 from starlette.middleware.sessions import SessionMiddleware
 from sqlalchemy import delete, text, func
 from passlib.context import CryptContext
+import os
 import secrets
 import uuid
 import json
 from fastapi.exceptions import RequestValidationError
-from fastapi.responses import JSONResponse
 
 # ---------- DB ----------
 DB_URL = "sqlite:///app.db"
 engine = create_engine(DB_URL, echo=False)
+
+
+def get_session() -> Iterator[Session]:
+    with Session(engine) as session:
+        yield session
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
@@ -60,11 +65,12 @@ class RecipeTag(SQLModel, table=True):
     tag_id: int = Field(foreign_key="tag.id", primary_key=True)
 
 # ---------- App ----------
+SECRET_KEY = os.environ.get("SECRET_KEY", "CHANGE_ME_TO_RANDOM_AND_SECRET")
 app = FastAPI()
-app.add_middleware(SessionMiddleware, secret_key="CHANGE_ME_TO_RANDOM_AND_SECRET", same_site="lax")
+app.add_middleware(SessionMiddleware, secret_key=SECRET_KEY, same_site="lax")
 app.mount("/static", StaticFiles(directory="app/static"), name="static")
 app.mount("/media", StaticFiles(directory="app/media"), name="media")
-app.mount("/static", StaticFiles(directory="app/static/css"), name="css")
+# Removed duplicate /static mount
 templates = Jinja2Templates(directory="app/templates")
 Path("app/media").mkdir(parents=True, exist_ok=True)
 
@@ -88,12 +94,11 @@ def _migrate_sqlite():
             conn.exec_driver_sql("ALTER TABLE recipe ADD COLUMN author_id INTEGER;")
 
 # ---------- Auth helpers ----------
-def get_current_user(request: Request) -> Optional[User]:
+def get_current_user(request: Request, session: Session) -> Optional[User]:
     uid = request.session.get("user_id")
     if not uid:
         return None
-    with Session(engine) as s:
-        return s.get(User, uid)
+    return session.get(User, uid)
 
 def _ensure_csrf(request: Request):
     if not request.session.get("csrf_token"):
@@ -104,8 +109,8 @@ def verify_csrf(request: Request, token: str):
     if not sess_token or not token or not secrets.compare_digest(sess_token, token):
         raise HTTPException(status_code=400, detail="Invalid CSRF token")
 
-def _require_login(request: Request) -> User:
-    user = get_current_user(request)
+def _require_login(request: Request, session: Session) -> User:
+    user = get_current_user(request, session)
     if not user:
         # 画面遷移前提の保護は 303 リダイレクトで返す
         raise HTTPException(status_code=401, detail="Login required")
@@ -118,7 +123,7 @@ def _get_recipe_or_404(session: Session, rid: int) -> Recipe:
     return r
 
 def _require_owner(request: Request, session: Session, rid: int):
-    user = _require_login(request)
+    user = _require_login(request, session)
     r = _get_recipe_or_404(session, rid)
     if r.author_id != user.id:
         raise HTTPException(status_code=403, detail="Forbidden")
@@ -127,6 +132,8 @@ def _require_owner(request: Request, session: Session, rid: int):
 def save_step_image(upload: UploadFile, crop_x=None, crop_y=None, crop_w=None, crop_h=None) -> str:
     if not upload or not upload.filename:
         return None
+    if upload.content_type not in ("image/jpeg", "image/png", "image/webp"):
+        raise HTTPException(status_code=400, detail="Unsupported image type")
     fname = f"{uuid.uuid4().hex}.webp"
     out = Path("app/media") / fname
     data = upload.file.read()
@@ -177,74 +184,73 @@ def _to_int_or_none(v) -> Optional[int]:
 # ---------- Routes ----------
 # 一覧＋検索＋タグ絞り込み
 @app.get("/", response_class=HTMLResponse)
-def index(request: Request, q: Optional[str] = None, tag: Optional[str] = None):
+def index(request: Request, q: Optional[str] = None, tag: Optional[str] = None, session: Session = Depends(get_session)):
     _ensure_csrf(request)
-    current_user = get_current_user(request)
-    with Session(engine) as s:
-        stmt = select(Recipe)
-        if q:
-            stmt = stmt.where((Recipe.title.contains(q)) | (Recipe.description.contains(q)))
-        if tag:
-            t = s.exec(select(Tag).where(Tag.name == tag.strip())).first()
-            if not t:
-                return templates.TemplateResponse("index.html",
-                    {"request": request, "recipes": [], "q": q or "", "tag": tag, "current_user": current_user})
-            rid_rows = s.exec(select(RecipeTag.recipe_id).where(RecipeTag.tag_id == t.id)).all()
-            rid_list = [r for (r,) in rid_rows] if rid_rows and isinstance(rid_rows[0], tuple) else rid_rows
-            if rid_list:
-                stmt = stmt.where(Recipe.id.in_(rid_list))
-            else:
-                return templates.TemplateResponse("index.html",
-                    {"request": request, "recipes": [], "q": q or "", "tag": tag, "current_user": current_user})
-        recipes = s.exec(stmt.order_by(Recipe.id.desc())).all()
+    current_user = get_current_user(request, session)
+    stmt = select(Recipe)
+    if q:
+        stmt = stmt.where((Recipe.title.contains(q)) | (Recipe.description.contains(q)))
+    if tag:
+        t = session.exec(select(Tag).where(Tag.name == tag.strip())).first()
+        if not t:
+            return templates.TemplateResponse("index.html",
+                {"request": request, "recipes": [], "q": q or "", "tag": tag, "current_user": current_user})
+        rid_rows = session.exec(select(RecipeTag.recipe_id).where(RecipeTag.tag_id == t.id)).all()
+        rid_list = [r for (r,) in rid_rows] if rid_rows and isinstance(rid_rows[0], tuple) else rid_rows
+        if rid_list:
+            stmt = stmt.where(Recipe.id.in_(rid_list))
+        else:
+            return templates.TemplateResponse("index.html",
+                {"request": request, "recipes": [], "q": q or "", "tag": tag, "current_user": current_user})
+    recipes = session.exec(stmt.order_by(Recipe.id.desc())).all()
     return templates.TemplateResponse("index.html",
         {"request": request, "recipes": recipes, "q": q or "", "tag": tag or "", "current_user": current_user})
 
 # ---------- Auth: signup/login/logout ----------
 @app.get("/signup", response_class=HTMLResponse)
-def signup_form(request: Request):
+def signup_form(request: Request, session: Session = Depends(get_session)):
     _ensure_csrf(request)
     return templates.TemplateResponse("signup.html",
-        {"request": request, "csrf_token": request.session.get("csrf_token"), "current_user": get_current_user(request)})
+        {"request": request, "csrf_token": request.session.get("csrf_token"), "current_user": get_current_user(request, session)})
 
 @app.post("/signup", response_class=HTMLResponse)
 def signup(request: Request,
            email: str = Form(...),
            password: str = Form(...),
-           csrf_token: str = Form(...)):
+           csrf_token: str = Form(...),
+           session: Session = Depends(get_session)):
     verify_csrf(request, csrf_token)
-    with Session(engine) as s:
-        exists = s.exec(select(User).where(User.email == email)).first()
-        if exists:
-            _ensure_csrf(request)
-            return templates.TemplateResponse("signup.html",
-                {"request": request, "error": "このメールは既に登録済みです。", "csrf_token": request.session.get("csrf_token"),
-                 "current_user": get_current_user(request)})
-        u = User(email=email, password_hash=pwd_context.hash(password))
-        s.add(u); s.commit(); s.refresh(u)
-        request.session["user_id"] = u.id
+    exists = session.exec(select(User).where(User.email == email)).first()
+    if exists:
+        _ensure_csrf(request)
+        return templates.TemplateResponse("signup.html",
+            {"request": request, "error": "このメールは既に登録済みです。", "csrf_token": request.session.get("csrf_token"),
+             "current_user": get_current_user(request, session)})
+    u = User(email=email, password_hash=pwd_context.hash(password))
+    session.add(u); session.commit(); session.refresh(u)
+    request.session["user_id"] = u.id
     return RedirectResponse(url="/", status_code=303)
 
 @app.get("/login", response_class=HTMLResponse)
-def login_form(request: Request):
+def login_form(request: Request, session: Session = Depends(get_session)):
     _ensure_csrf(request)
     return templates.TemplateResponse("login.html",
-        {"request": request, "csrf_token": request.session.get("csrf_token"), "current_user": get_current_user(request)})
+        {"request": request, "csrf_token": request.session.get("csrf_token"), "current_user": get_current_user(request, session)})
 
 @app.post("/login", response_class=HTMLResponse)
 def login(request: Request,
           email: str = Form(...),
           password: str = Form(...),
-          csrf_token: str = Form(...)):
+          csrf_token: str = Form(...),
+          session: Session = Depends(get_session)):
     verify_csrf(request, csrf_token)
-    with Session(engine) as s:
-        u = s.exec(select(User).where(User.email == email)).first()
-        if not u or not pwd_context.verify(password, u.password_hash):
-            _ensure_csrf(request)
-            return templates.TemplateResponse("login.html",
-                {"request": request, "error": "メールまたはパスワードが違います。", "csrf_token": request.session.get("csrf_token"),
-                 "current_user": get_current_user(request)})
-        request.session["user_id"] = u.id
+    u = session.exec(select(User).where(User.email == email)).first()
+    if not u or not pwd_context.verify(password, u.password_hash):
+        _ensure_csrf(request)
+        return templates.TemplateResponse("login.html",
+            {"request": request, "error": "メールまたはパスワードが違います。", "csrf_token": request.session.get("csrf_token"),
+             "current_user": get_current_user(request, session)})
+    request.session["user_id"] = u.id
     return RedirectResponse(url="/", status_code=303)
 
 @app.post("/logout")
@@ -255,8 +261,8 @@ def logout(request: Request, csrf_token: str = Form(...)):
 
 # ---------- Recipes: new/create ----------
 @app.get("/recipes/new", response_class=HTMLResponse)
-def recipe_new(request: Request):
-    current_user = get_current_user(request)
+def recipe_new(request: Request, session: Session = Depends(get_session)):
+    current_user = get_current_user(request, session)
     if not current_user:
         return RedirectResponse(url="/login", status_code=303)
     _ensure_csrf(request)
@@ -274,7 +280,7 @@ async def recipe_create(
     ingredients_unit: List[str] = Form([]),
     steps_body: List[str] = Form([]),
     steps_image: List[UploadFile] = File([]),     # ★ 手順画像
-    
+
     steps_crop_x: Optional[List[str]] = Form(None),
     steps_crop_y: Optional[List[str]] = Form(None),
     steps_crop_w: Optional[List[str]] = Form(None),
@@ -286,8 +292,9 @@ async def recipe_create(
     crop_w: float = Form(None),
     crop_h: float = Form(None),
     csrf_token: str = Form(...),
+    session: Session = Depends(get_session),
 ):
-    current_user = get_current_user(request)
+    current_user = get_current_user(request, session)
     if not current_user:
         return RedirectResponse(url="/login", status_code=303)
     verify_csrf(request, csrf_token)
@@ -313,64 +320,66 @@ async def recipe_create(
                 im.save(out, format="WEBP", quality=85)
         except Exception:
             pass
-        saved_path = f"/media/{fname}+"
+        saved_path = f"/media/{fname}"
 
-    with Session(engine) as s:
-        # レシピ本体
-        r = Recipe(title=title, description=description, main_image=saved_path, author_id=current_user.id)
-        s.add(r); s.commit(); s.refresh(r)
+    # レシピ本体
+    r = Recipe(title=title, description=description, main_image=saved_path, author_id=current_user.id)
+    session.add(r); session.commit(); session.refresh(r)
 
-        # 材料
-        for idx, name in enumerate(ingredients_name or []):
-            name = (name or "").strip()
-            if not name: 
-                continue
-            amount = (ingredients_amount[idx] if idx < len(ingredients_amount) else None) or None
-            unit   = (ingredients_unit[idx]   if idx < len(ingredients_unit)   else None) or None
-            s.add(Ingredient(
-                recipe_id=r.id, name=name,
-                amount=(amount.strip() if amount else None),
-                unit=(unit.strip() if unit else None),
-                order_no=idx,
-            ))
+    # 材料
+    for idx, name in enumerate(ingredients_name or []):
+        name = (name or "").strip()
+        if not name:
+            continue
+        amount = (ingredients_amount[idx] if idx < len(ingredients_amount) else None) or None
+        unit   = (ingredients_unit[idx]   if idx < len(ingredients_unit)   else None) or None
+        session.add(Ingredient(
+            recipe_id=r.id, name=name,
+            amount=(amount.strip() if amount else None),
+            unit=(unit.strip() if unit else None),
+            order_no=idx,
+        ))
 
-        # 手順（本文＋画像）※画像のみの手順もOK
-        max_len = max(len(steps_body or []), len(steps_image or []))
-        for idx in range(max_len):
-            body = (steps_body[idx] if idx < len(steps_body) else "") or ""
-            body = body.strip()
-            if idx < len(steps_body):
-                body = (steps_body[idx] or "").strip()
-            img_path = None
-            if idx < len(steps_image):
-                up = steps_image[idx]
-                if up and getattr(up, "filename", None):
-                    crop = _crop_tuple_at(idx, steps_crop_x, steps_crop_y, steps_crop_w, steps_crop_h)
+    # 手順（本文＋画像）※画像のみの手順もOK
+    max_len = max(len(steps_body or []), len(steps_image or []))
+    for idx in range(max_len):
+        body = (steps_body[idx] if idx < len(steps_body) else "") or ""
+        body = body.strip()
+        if idx < len(steps_body):
+            body = (steps_body[idx] or "").strip()
+        img_path = None
+        if idx < len(steps_image):
+            up = steps_image[idx]
+            if up and getattr(up, "filename", None):
+                crop = _crop_tuple_at(idx, steps_crop_x, steps_crop_y, steps_crop_w, steps_crop_h)
+                if crop:
+                    img_path = save_step_image(up, crop_x=crop[0], crop_y=crop[1], crop_w=crop[2], crop_h=crop[3])
+                else:
                     img_path = save_step_image(up)
-            if not body and not img_path:
-                continue
-            s.add(Step(recipe_id=r.id, body=body or "", order_no=idx, image_path=img_path))
+        if not body and not img_path:
+            continue
+        session.add(Step(recipe_id=r.id, body=body or "", order_no=idx, image_path=img_path))
 
-        # タグ
-        for raw in (tags_csv or "").split(","):
-            tname = raw.strip()
-            if not tname: 
-                continue
-            t = s.exec(select(Tag).where(Tag.name == tname)).first()
-            if not t:
-                t = Tag(name=tname); s.add(t); s.commit(); s.refresh(t)
-            exists = s.exec(select(RecipeTag).where(
-                (RecipeTag.recipe_id == r.id) & (RecipeTag.tag_id == t.id)
-            )).first()
-            if not exists:
-                s.add(RecipeTag(recipe_id=r.id, tag_id=t.id))
+    # タグ
+    for raw in (tags_csv or "").split(","):
+        tname = raw.strip()
+        if not tname:
+            continue
+        t = session.exec(select(Tag).where(Tag.name == tname)).first()
+        if not t:
+            t = Tag(name=tname); session.add(t); session.commit(); session.refresh(t)
+        exists = session.exec(select(RecipeTag).where(
+            (RecipeTag.recipe_id == r.id) & (RecipeTag.tag_id == t.id)
+        )).first()
+        if not exists:
+            session.add(RecipeTag(recipe_id=r.id, tag_id=t.id))
 
-        s.commit()
+    session.commit()
 
-        # 表示用
-        ings  = s.exec(select(Ingredient).where(Ingredient.recipe_id == r.id).order_by(Ingredient.order_no)).all()
-        steps = s.exec(select(Step).where(Step.recipe_id == r.id).order_by(Step.order_no)).all()
-        tags  = s.exec(select(Tag).join(RecipeTag, RecipeTag.tag_id == Tag.id).where(RecipeTag.recipe_id == r.id)).all()
+    # 表示用
+    ings  = session.exec(select(Ingredient).where(Ingredient.recipe_id == r.id).order_by(Ingredient.order_no)).all()
+    steps = session.exec(select(Step).where(Step.recipe_id == r.id).order_by(Step.order_no)).all()
+    tags  = session.exec(select(Tag).join(RecipeTag, RecipeTag.tag_id == Tag.id).where(RecipeTag.recipe_id == r.id)).all()
 
     return templates.TemplateResponse(
         "recipe_detail.html",
@@ -380,19 +389,18 @@ async def recipe_create(
 
 # ---------- Recipes: detail ----------
 @app.get("/recipes/{rid}", response_class=HTMLResponse)
-def recipe_detail(request: Request, rid: int):
+def recipe_detail(request: Request, rid: int, session: Session = Depends(get_session)):
     _ensure_csrf(request)
-    current_user = get_current_user(request)
-    with Session(engine) as s:
-        r = s.get(Recipe, rid)
-        if not r:
-            return HTMLResponse("Not found", status_code=404)
-        ings = s.exec(select(Ingredient).where(Ingredient.recipe_id == rid).order_by(Ingredient.order_no)).all()
-        steps = s.exec(select(Step).where(Step.recipe_id == rid).order_by(Step.order_no)).all()
-        tags = s.exec(select(Tag).join(RecipeTag, RecipeTag.tag_id == Tag.id).where(RecipeTag.recipe_id == rid)).all()
+    current_user = get_current_user(request, session)
+    r = session.get(Recipe, rid)
+    if not r:
+        return HTMLResponse("Not found", status_code=404)
+    ings = session.exec(select(Ingredient).where(Ingredient.recipe_id == rid).order_by(Ingredient.order_no)).all()
+    steps = session.exec(select(Step).where(Step.recipe_id == rid).order_by(Step.order_no)).all()
+    tags = session.exec(select(Tag).join(RecipeTag, RecipeTag.tag_id == Tag.id).where(RecipeTag.recipe_id == rid)).all()
 
-        fav_count = _fav_count(s, rid)
-        is_fav = (current_user is not None) and _is_favorited(s, current_user.id, rid)
+    fav_count = _fav_count(session, rid)
+    is_fav = (current_user is not None) and _is_favorited(session, current_user.id, rid)
 
     return templates.TemplateResponse("recipe_detail.html", {
         "request": request, "recipe": r, "ingredients": ings, "steps": steps, "tags": tags,
@@ -401,13 +409,12 @@ def recipe_detail(request: Request, rid: int):
 
 # ---------- Recipes: edit (GET/POST) ----------
 @app.get("/recipes/{rid}/edit", response_class=HTMLResponse)
-def recipe_edit_form(request: Request, rid: int):
+def recipe_edit_form(request: Request, rid: int, session: Session = Depends(get_session)):
     _ensure_csrf(request)
-    with Session(engine) as s:
-        r, user = _require_owner(request, s, rid)
-        ings = s.exec(select(Ingredient).where(Ingredient.recipe_id == rid).order_by(Ingredient.order_no)).all()
-        steps = s.exec(select(Step).where(Step.recipe_id == rid).order_by(Step.order_no)).all()
-        tags = s.exec(select(Tag).join(RecipeTag, RecipeTag.tag_id == Tag.id).where(RecipeTag.recipe_id == rid)).all()
+    r, user = _require_owner(request, session, rid)
+    ings = session.exec(select(Ingredient).where(Ingredient.recipe_id == rid).order_by(Ingredient.order_no)).all()
+    steps = session.exec(select(Step).where(Step.recipe_id == rid).order_by(Step.order_no)).all()
+    tags = session.exec(select(Tag).join(RecipeTag, RecipeTag.tag_id == Tag.id).where(RecipeTag.recipe_id == rid)).all()
     tags_csv = ", ".join(t.name for t in tags)
     return templates.TemplateResponse("recipe_edit.html",
         {"request": request, "recipe": r, "ingredients": ings, "steps": steps, "tags_csv": tags_csv,
@@ -431,6 +438,10 @@ async def recipe_update(
     steps_body: Optional[List[str]] = Form(None),
     steps_existing_image: Optional[List[str]] = Form(None),
     steps_image: Optional[List[UploadFile]] = File(None),
+    steps_crop_x: Optional[List[str]] = Form(None),
+    steps_crop_y: Optional[List[str]] = Form(None),
+    steps_crop_w: Optional[List[str]] = Form(None),
+    steps_crop_h: Optional[List[str]] = Form(None),
 
     tags_csv: str = Form(""),
 
@@ -439,8 +450,9 @@ async def recipe_update(
     crop_y: Optional[str] = Form(None),
     crop_w: Optional[str] = Form(None),
     crop_h: Optional[str] = Form(None),
+    session: Session = Depends(get_session),
 ):
-    current_user = get_current_user(request)
+    current_user = get_current_user(request, session)
     if not current_user:
         return RedirectResponse(url="/login", status_code=303)
     verify_csrf(request, csrf_token)
@@ -450,101 +462,107 @@ async def recipe_update(
     cw = _to_float_or_none(crop_w)
     ch = _to_float_or_none(crop_h)
 
-    with Session(engine) as s:
-        r = s.get(Recipe, rid)
-        if not r: return HTMLResponse("Not found", status_code=404)
-        if r.author_id != current_user.id: return HTMLResponse("Forbidden", status_code=403)
+    r = session.get(Recipe, rid)
+    if not r:
+        return HTMLResponse("Not found", status_code=404)
+    if r.author_id != current_user.id:
+        return HTMLResponse("Forbidden", status_code=403)
 
-        # メイン画像（差し替え時のみ）
-        if image and getattr(image, "filename", None):
-            fname = f"{uuid.uuid4().hex}.webp"
-            out = Path("app/media") / fname
-            data = await image.read()
-            out.write_bytes(data)
-            try:
-                with Image.open(out) as im0:
-                    im = ImageOps.exif_transpose(im0)
-                    im.thumbnail((1600, 1600))
-                    if all(v is not None for v in (cx, cy, cw, ch)):
-                        x = max(0, int(cx)); y = max(0, int(cy))
-                        w = max(1, int(cw)); h = max(1, int(ch))
-                        w = min(w, im.width - x); h = min(h, im.height - y)
-                        im = im.crop((x, y, x + w, y + h)).resize((1200, 675), Image.LANCZOS)
-                    im.save(out, format="WEBP", quality=85)
-            except Exception:
-                pass
-            r.main_image = f"/media/{fname}+"
+    # メイン画像（差し替え時のみ）
+    if image and getattr(image, "filename", None):
+        fname = f"{uuid.uuid4().hex}.webp"
+        out = Path("app/media") / fname
+        data = await image.read()
+        out.write_bytes(data)
+        try:
+            with Image.open(out) as im0:
+                im = ImageOps.exif_transpose(im0)
+                im.thumbnail((1600, 1600))
+                if all(v is not None for v in (cx, cy, cw, ch)):
+                    x = max(0, int(cx)); y = max(0, int(cy))
+                    w = max(1, int(cw)); h = max(1, int(ch))
+                    w = min(w, im.width - x); h = min(h, im.height - y)
+                    im = im.crop((x, y, x + w, y + h)).resize((1200, 675), Image.LANCZOS)
+                im.save(out, format="WEBP", quality=85)
+        except Exception:
+            pass
+        r.main_image = f"/media/{fname}"
 
-        # 本文
-        r.title = title
-        r.description = description
-        s.add(r); s.commit()
+    # 本文
+    r.title = title
+    r.description = description
+    session.add(r); session.commit()
 
-        # 材料：全削除→再作成（テンプレは unit を送っていない）
-        s.exec(delete(Ingredient).where(Ingredient.recipe_id == rid))
-        names   = ingredients_name  or []
-        amounts = ingredients_amount or []
-        for idx, name in enumerate(names):
-            name = (name or "").strip()
-            if not name: continue
-            amount = (amounts[idx] if idx < len(amounts) else None) or None
-            s.add(Ingredient(
-                recipe_id=rid, name=name,
-                amount=(amount.strip() if amount else None),
-                unit=None, order_no=idx,
-            ))
+    # 材料：全削除→再作成（テンプレは unit を送っていない）
+    session.exec(delete(Ingredient).where(Ingredient.recipe_id == rid))
+    names   = ingredients_name  or []
+    amounts = ingredients_amount or []
+    for idx, name in enumerate(names):
+        name = (name or "").strip()
+        if not name:
+            continue
+        amount = (amounts[idx] if idx < len(amounts) else None) or None
+        session.add(Ingredient(
+            recipe_id=rid, name=name,
+            amount=(amount.strip() if amount else None),
+            unit=None, order_no=idx,
+        ))
 
-        # 手順：全削除→再作成（本文＋画像）
-        s.exec(delete(Step).where(Step.recipe_id == rid))
-        bodies = steps_body or []
-        olds   = steps_existing_image or []
-        imgs   = steps_image or []
-        max_len = max(len(bodies), len(olds), len(imgs))
-        for idx in range(max_len):
-            body = ((bodies[idx] if idx < len(bodies) else "") or "").strip()
-            keep = (olds[idx] if idx < len(olds) else None) or None
+    # 手順：全削除→再作成（本文＋画像）
+    session.exec(delete(Step).where(Step.recipe_id == rid))
+    bodies = steps_body or []
+    olds   = steps_existing_image or []
+    imgs   = steps_image or []
+    max_len = max(len(bodies), len(olds), len(imgs))
+    for idx in range(max_len):
+        body = ((bodies[idx] if idx < len(bodies) else "") or "").strip()
+        keep = (olds[idx] if idx < len(olds) else None) or None
 
-            img_path = None
-            if idx < len(imgs):
-                up = imgs[idx]
-                if up and getattr(up, "filename", None):
+        img_path = None
+        if idx < len(imgs):
+            up = imgs[idx]
+            if up and getattr(up, "filename", None):
+                crop = _crop_tuple_at(idx, steps_crop_x, steps_crop_y, steps_crop_w, steps_crop_h)
+                if crop:
+                    img_path = save_step_image(up, crop_x=crop[0], crop_y=crop[1], crop_w=crop[2], crop_h=crop[3])
+                else:
                     img_path = save_step_image(up)
-            if not img_path:
-                img_path = keep  # 削除チェックはテンプレ未実装なので維持
+        if not img_path:
+            img_path = keep  # 削除チェックはテンプレ未実装なので維持
 
-            if not body and not img_path:
-                continue
-            s.add(Step(recipe_id=rid, body=body, order_no=idx, image_path=img_path))
+        if not body and not img_path:
+            continue
+        session.add(Step(recipe_id=rid, body=body, order_no=idx, image_path=img_path))
 
-        # タグ（追加的に）
-        for raw in (tags_csv or "").split(","):
-            tname = raw.strip()
-            if not tname: continue
-            t = s.exec(select(Tag).where(Tag.name == tname)).first()
-            if not t:
-                t = Tag(name=tname); s.add(t); s.commit(); s.refresh(t)
-            exists = s.exec(select(RecipeTag).where(
-                (RecipeTag.recipe_id == rid) & (RecipeTag.tag_id == t.id)
-            )).first()
-            if not exists:
-                s.add(RecipeTag(recipe_id=rid, tag_id=t.id))
+    # タグ（追加的に）
+    for raw in (tags_csv or "").split(","):
+        tname = raw.strip()
+        if not tname:
+            continue
+        t = session.exec(select(Tag).where(Tag.name == tname)).first()
+        if not t:
+            t = Tag(name=tname); session.add(t); session.commit(); session.refresh(t)
+        exists = session.exec(select(RecipeTag).where(
+            (RecipeTag.recipe_id == rid) & (RecipeTag.tag_id == t.id)
+        )).first()
+        if not exists:
+            session.add(RecipeTag(recipe_id=rid, tag_id=t.id))
 
-        s.commit()
+    session.commit()
 
     return RedirectResponse(url=f"/recipes/{rid}", status_code=303)
 # ---------- Recipes: delete ----------
 @app.post("/recipes/{rid}/delete")
-def recipe_delete(request: Request, rid: int, csrf_token: str = Form(...)):
+def recipe_delete(request: Request, rid: int, csrf_token: str = Form(...), session: Session = Depends(get_session)):
     verify_csrf(request, csrf_token)
-    with Session(engine) as s:
-        r, user = _require_owner(request, s, rid)  # 所有者チェック（自作ヘルパ）
-        # 子テーブル削除（お気に入りも忘れずに）
-        s.exec(delete(Ingredient).where(Ingredient.recipe_id == rid))
-        s.exec(delete(Step).where(Step.recipe_id == rid))
-        s.exec(delete(RecipeTag).where(RecipeTag.recipe_id == rid))
-        s.exec(delete(Favorite).where(Favorite.recipe_id == rid))  # ★お気に入りの孤児防止
-        s.delete(r)
-        s.commit()
+    r, user = _require_owner(request, session, rid)  # 所有者チェック（自作ヘルパ）
+    # 子テーブル削除（お気に入りも忘れずに）
+    session.exec(delete(Ingredient).where(Ingredient.recipe_id == rid))
+    session.exec(delete(Step).where(Step.recipe_id == rid))
+    session.exec(delete(RecipeTag).where(RecipeTag.recipe_id == rid))
+    session.exec(delete(Favorite).where(Favorite.recipe_id == rid))  # ★お気に入りの孤児防止
+    session.delete(r)
+    session.commit()
     return RedirectResponse(url="/", status_code=303)
 
 # ---------- PWA manifest / SW / favicon ----------
@@ -588,11 +606,11 @@ def _parse_crop(x, y, w, h):
         return None
     
 @app.get("/account", response_class=HTMLResponse)
-def account_page(request: Request):
+def account_page(request: Request, session: Session = Depends(get_session)):
     _ensure_csrf(request)
     return templates.TemplateResponse("account.html", {
         "request": request,
-        "current_user": get_current_user(request),
+        "current_user": get_current_user(request, session),
         "csrf_token": request.session.get("csrf_token"),
     })
 
@@ -609,46 +627,42 @@ def _fav_count(session: Session, recipe_id: int) -> int:
 
 # 追加
 @app.post("/recipes/{rid}/favorite")
-def favorite_recipe(request: Request, rid: int, csrf_token: str = Form(...)):
-    user = get_current_user(request)
+def favorite_recipe(request: Request, rid: int, csrf_token: str = Form(...), session: Session = Depends(get_session)):
+    user = get_current_user(request, session)
     if not user:
         return RedirectResponse(url="/login", status_code=303)
     verify_csrf(request, csrf_token)
-    with Session(engine) as s:
-        exists = s.exec(select(Favorite).where(
-            (Favorite.user_id == user.id) & (Favorite.recipe_id == rid)
-        )).first()
-        if not exists:
-            s.add(Favorite(user_id=user.id, recipe_id=rid)); s.commit()
+    exists = session.exec(select(Favorite).where(
+        (Favorite.user_id == user.id) & (Favorite.recipe_id == rid)
+    )).first()
+    if not exists:
+        session.add(Favorite(user_id=user.id, recipe_id=rid)); session.commit()
     # Ajax対応なら 204 でもOK。ここは一覧/詳細へ戻す
     return RedirectResponse(url=f"/recipes/{rid}", status_code=303)
 
 
 # 解除
 @app.post("/recipes/{rid}/unfavorite")
-def unfavorite_recipe(request: Request, rid: int, csrf_token: str = Form(...)):
-    user = get_current_user(request)
+def unfavorite_recipe(request: Request, rid: int, csrf_token: str = Form(...), session: Session = Depends(get_session)):
+    user = get_current_user(request, session)
     if not user:
         return RedirectResponse(url="/login", status_code=303)
     verify_csrf(request, csrf_token)
-    with Session(engine) as s:
-        s.exec(delete(Favorite).where((Favorite.user_id == user.id) & (Favorite.recipe_id == rid)))
-        s.commit()
+    session.exec(delete(Favorite).where((Favorite.user_id == user.id) & (Favorite.recipe_id == rid)))
+    session.commit()
     return RedirectResponse(url=f"/recipes/{rid}", status_code=303)
 
 # お気に入り一覧ページ
 @app.get("/favorites", response_class=HTMLResponse)
-def favorites_page(request: Request):
+def favorites_page(request: Request, session: Session = Depends(get_session)):
     _ensure_csrf(request)
-    user = _require_login(request)
-    with Session(engine) as s:
-        # ユーザーのお気に入り recipe を新着順（recipe.id desc）で取得
-        fav_rids = s.exec(select(Favorite.recipe_id).where(Favorite.user_id == user.id)).all()
-        if not fav_rids:
-            recipes = []
-        else:
-            rid_list = [r for (r,) in fav_rids] if isinstance(fav_rids[0], tuple) else fav_rids
-            recipes = s.exec(select(Recipe).where(Recipe.id.in_(rid_list)).order_by(Recipe.id.desc())).all()
+    user = _require_login(request, session)
+    fav_rids = session.exec(select(Favorite.recipe_id).where(Favorite.user_id == user.id)).all()
+    if not fav_rids:
+        recipes = []
+    else:
+        rid_list = [r for (r,) in fav_rids] if isinstance(fav_rids[0], tuple) else fav_rids
+        recipes = session.exec(select(Recipe).where(Recipe.id.in_(rid_list)).order_by(Recipe.id.desc())).all()
     return templates.TemplateResponse("favorites.html", {
         "request": request,
         "recipes": recipes,
@@ -656,9 +670,9 @@ def favorites_page(request: Request):
     })
 
 @app.get("/offline", response_class=HTMLResponse)
-def offline_page(request: Request):
+def offline_page(request: Request, session: Session = Depends(get_session)):
     return templates.TemplateResponse("offline.html", {
         "request": request,
-        "current_user": get_current_user(request),
+        "current_user": get_current_user(request, session),
     })
 


### PR DESCRIPTION
## Summary
- Externalize session secret, remove redundant static mount, and centralize DB sessions via dependency injection
- Clean up image handling by dropping '+' suffix, enforcing crop data, and validating uploads

## Testing
- `python -m py_compile app/main.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3ecd9827c83268be4d68eb6e5c5ee